### PR TITLE
[Release to GitHub and PyPi] Update release workflow to use GitHub Release reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,25 +188,25 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-  pypi-release:
-    if: ${{ !inputs.test_run }}
+  # pypi-release:
+  #   if: ${{ !inputs.test_run }}
 
-    name: Pypi Release
+  #   name: Pypi Release
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    needs: github-release
+  #   needs: github-release
 
-    environment: PypiProd
+  #   environment: PypiProd
 
-    steps:
-      - name: "Download Build Artifact - ${{ inputs.version_number }}"
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.version_number }}
-          path: "dist"
+  #   steps:
+  #     - name: "Download Build Artifact - ${{ inputs.version_number }}"
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: ${{ inputs.version_number }}
+  #         path: "dist"
 
-      - name: "Publish Distribution To Pypi"
-        uses: pypa/gh-action-pypi-publish@v1.4.2
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: "Publish Distribution To Pypi"
+  #       uses: pypa/gh-action-pypi-publish@v1.4.2
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,28 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-       description: 'The last commit sha in the release'
-       required: true
+        description: "The last commit sha in the release"
+        required: true
       version_number:
-       description: 'The release version number (i.e. 1.0.0b1)'
-       required: true
+        description: "The release version number (i.e. 1.0.0b1)"
+        required: true
+      changelog_path:
+        description: "Path to changes log"
+        type: string
+        default: "./CHANGELOG.md"
+        required: false
+      test_run:
+        description: "Launch test run"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write # this is the permission that allows creating a new release
+
+env:
+  PYTHON_TARGET_VERSION: 3.8
+  ARTIFACT_RETENTION_DAYS: 1
 
 defaults:
   run:
@@ -29,7 +43,7 @@ defaults:
 
 jobs:
   unit:
-    name: Unit test
+    name: Unit Test
 
     runs-on: ubuntu-latest
 
@@ -37,111 +51,114 @@ jobs:
       TOXENV: "unit"
 
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.sha }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: Install python dependencies
+      - name: "Install Python Dependencies"
         run: |
-          pip install --user --upgrade pip
-          pip install tox
-          pip --version
-          tox --version
+          python -m pip install --user --upgrade pip
+          python -m pip install tox
+          python -m pip --version
+          python -m tox --version
 
-      - name: Run tox
+      - name: "Run Tox"
         run: tox
 
   build:
-    name: build packages
+    name: Build Packages
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ inputs.sha }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: Install python dependencies
+      - name: "Install Python Dependencies"
         run: |
-          pip install --user --upgrade pip
-          pip install --upgrade setuptools wheel twine check-wheel-contents
-          pip --version
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
+          python -m pip --version
 
-      - name: Build distributions
+      - name: "Build Distributions"
         run: ./scripts/build-dist.sh
 
-      - name: Show distributions
+      - name: "[DEBUG] Show Distributions"
         run: ls -lh dist/
 
-      - name: Check distribution descriptions
+      - name: "Check Distribution Descriptions"
         run: |
           twine check dist/*
 
-      - name: Check wheel contents
+      - name: "[DEBUG] Check Wheel Contents"
         run: |
           check-wheel-contents dist/*.whl --ignore W007,W008
 
-      - uses: actions/upload-artifact@v2
+      - name: "Upload Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/upload-artifact@v3
         with:
-          name: dist
+          name: ${{ inputs.version_number }}
           path: |
             dist/
-            !dist/dbt-${{github.event.inputs.version_number}}.tar.gz
+            !dist/dbt-${{ inputs.version_number }}.tar.gz
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
   test-build:
-    name: verify packages
+    name: Verify Packages
 
-    needs: [build, unit]
+    needs: [unit, build]
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: Install python dependencies
+      - name: "Install Python Dependencies"
         run: |
-          pip install --user --upgrade pip
-          pip install --upgrade wheel
-          pip --version
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip --version
 
-      - uses: actions/download-artifact@v2
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: ${{ inputs.version_number }}
           path: dist/
 
-      - name: Show distributions
+      - name: "[DEBUG] Show Distributions"
         run: ls -lh dist/
 
-      - name: Install wheel distributions
+      - name: "Install Wheel Distributions"
         run: |
-          find ./dist/*.whl -maxdepth 1 -type f | xargs pip install --force-reinstall --find-links=dist/
+          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
 
-      - name: Check wheel distributions
+      - name: "[DEBUG] Check Wheel Distributions"
         run: |
           dbt --version
 
-      - name: Install source distributions
+      - name: "Install Source Distributions"
         run: |
-          find ./dist/*.gz -maxdepth 1 -type f | xargs pip install --force-reinstall --find-links=dist/
+          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
 
-      - name: Check source distributions
+      - name: "[DEBUG] Check Source Distributions"
         run: |
           dbt --version
 
@@ -150,53 +167,33 @@ jobs:
 
     needs: test-build
 
-    runs-on: ubuntu-latest
+    uses: dbt-labs/dbt-release/.github/workflows/_github-release.yml@main
 
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: '.'
-
-      # Need to set an output variable because env variables can't be taken as input
-      # This is needed for the next step with releasing to GitHub
-      - name: Find release type
-        id: release_type
-        env:
-          IS_PRERELEASE: ${{ contains(github.event.inputs.version_number, 'rc') ||  contains(github.event.inputs.version_number, 'b') }}
-        run: |
-          echo ::set-output name=isPrerelease::$IS_PRERELEASE
-
-      - name: Creating GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: dbt-core v${{github.event.inputs.version_number}}
-          tag_name: v${{github.event.inputs.version_number}}
-          prerelease: ${{ steps.release_type.outputs.isPrerelease }}
-          target_commitish: ${{github.event.inputs.sha}}
-          body: |
-            [Release notes](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md)
-          files: |
-            dbt_postgres-${{github.event.inputs.version_number}}-py3-none-any.whl
-            dbt_core-${{github.event.inputs.version_number}}-py3-none-any.whl
-            dbt-postgres-${{github.event.inputs.version_number}}.tar.gz
-            dbt-core-${{github.event.inputs.version_number}}.tar.gz
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      test_run: ${{ inputs.test_run }}
 
   pypi-release:
-    name: Pypi release
+    if: ${{ !inputs.test_run }}
+
+    name: Pypi Release
 
     runs-on: ubuntu-latest
 
     needs: github-release
 
     environment: PypiProd
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: 'dist'
 
-      - name: Publish distribution to PyPI
+    steps:
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: "dist"
+
+      - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
 
     needs: test-build
 
-    uses: dbt-labs/dbt-release/.github/workflows/_github-release.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,19 @@ defaults:
     shell: bash
 
 jobs:
+  log-inputs:
+    name: Log Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo The last commit sha in the release: ${{ inputs.sha }}
+          echo The release version number:         ${{ inputs.version_number }}
+          echo Expected Changlog path:             ${{ inputs.changelog_path }}
+          echo Test run:                           ${{ inputs.test_run }}
+          echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
+          echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
+
   unit:
     name: Unit Test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,25 +188,25 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-  # pypi-release:
-  #   if: ${{ !inputs.test_run }}
+  pypi-release:
+    if: ${{ !inputs.test_run }}
 
-  #   name: Pypi Release
+    name: Pypi Release
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   needs: github-release
+    needs: github-release
 
-  #   environment: PypiProd
+    environment: PypiProd
 
-  #   steps:
-  #     - name: "Download Build Artifact - ${{ inputs.version_number }}"
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ inputs.version_number }}
-  #         path: "dist"
+    steps:
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: "dist"
 
-  #     - name: "Publish Distribution To Pypi"
-  #       uses: pypa/gh-action-pypi-publish@v1.4.2
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: "Publish Distribution To Pypi"
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
         default: "./CHANGELOG.md"
         required: false
       test_run:
-        description: "Launch test run"
+        description: "Test run (Publish release as draft)"
         type: boolean
         default: false
         required: false

--- a/.github/workflows/test_publish_github_release.yml
+++ b/.github/workflows/test_publish_github_release.yml
@@ -47,7 +47,7 @@ jobs:
   publish-github-release:
     if: ${{ always() && !cancelled() }}
     needs: [build-test-verify-publish-package]
-    uses: dbt-labs/dbt-release/.github/workflows/_github-release.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}


### PR DESCRIPTION
**Description**:
We need to update the `release.yml` to replace the GitHub Release stage with a reusable workflow.

**Changelog**:
- Replaced the GitHub Release stage with a reusable workflow call;
- Formated code according to guidelines;
- Added inputs that are required for GitHub Release reusable workflow;
- Replaced hardcoded Python version with environment variable;
- Added `python -m`  before calling `pip` to have more control over the environment;
- Bumped up the GH actions version to resolve warnings;
