### PR TITLE
[CI/CD] Replace build steps with build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
 
   github-release:
     name: GitHub Release
+    if: ${{ !failure() && !cancelled() }}
 
     needs: build-test-package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
   build-test-package:
     name: Build, Test, Package
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/update-build-workflow
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@amin
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
       audit_version_changelog: ${{ inputs.audit_version_changelog }}
       check_build_exists: ${{ inputs.check_build_exists }}
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
+      test_run: ${{ inputs.test_run }}
 
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           echo Build script path:                  ${{ inputs.build_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
           echo Package test command:               ${{ inputs.package_test_command }}
-          echo Check version changelog:            ${{ inputs.audit_version_changelog }} 
+          echo Check version changelog:            ${{ inputs.audit_version_changelog }}
           echo Check build exists:                 ${{ inputs.check_build_exists }}
           echo Upload build to AWS:                ${{ inputs.upload_artifacts_aws  }}
           echo Test run:                           ${{ inputs.test_run }}
@@ -104,7 +104,7 @@ jobs:
   github-release:
     name: GitHub Release
 
-    needs: test-build
+    needs: build-test-package
 
     uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,9 @@ jobs:
       check_build_exists: ${{ inputs.check_build_exists }}
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
 
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,6 @@ on:
         type: string
         default: "core-team-artifacts"
         required: true
-      s3_artifact_folder:
-        description: "Folder for arifact"
-        type: choice
-        required: true
-        options:
-          - "artifacts"
-          - "artifacts_testing"
-        default: "artifacts"
       package_test_command:
         description: "Package test command"
         type: string
@@ -87,7 +79,6 @@ jobs:
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Build script path:                  ${{ inputs.build_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
-          echo Folder for arifact:                 ${{ inputs.s3_artifact_folder }}
           echo Package test command:               ${{ inputs.package_test_command }}
           echo Check version changelog:            ${{ inputs.audit_version_changelog }}
           echo Check build exists:                 ${{ inputs.check_build_exists }}
@@ -105,7 +96,6 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       build_script_path: ${{ inputs.build_script_path }}
       s3_bucket_name: ${{ inputs.s3_bucket_name }}
-      s3_artifact_folder: ${{ inputs.s3_artifact_folder }}
       package_test_command: ${{ inputs.package_test_command }}
       audit_version_changelog: ${{ inputs.audit_version_changelog }}
       check_build_exists: ${{ inputs.check_build_exists }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
 
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,36 @@ on:
         type: string
         default: "./CHANGELOG.md"
         required: false
+      build_script_path:
+        description: "Build script path"
+        type: string
+        default: "scripts/build-dist.sh"
+        required: true
+      s3_bucket_name:
+        description: "AWS S3 bucket name"
+        type: string
+        default: "core-team-artifacts"
+        required: true
+      package_test_command:
+        description: "Package test command"
+        type: string
+        default: "dbt --version"
+        required: true
+      audit_version_changelog:
+        description: "Check version changelog"
+        type: boolean
+        default: false
+        required: false
+      check_build_exists:
+        description: "Check build exists"
+        type: boolean
+        default: false
+        required: false
+      upload_artifacts_aws:
+        description: "Upload build to AWS"
+        required: false
+        default: false
+        type: boolean
       test_run:
         description: "Test run (Publish release as draft)"
         type: boolean
@@ -32,10 +62,6 @@ on:
 
 permissions:
   contents: write # this is the permission that allows creating a new release
-
-env:
-  PYTHON_TARGET_VERSION: 3.8
-  ARTIFACT_RETENTION_DAYS: 1
 
 defaults:
   run:
@@ -51,129 +77,29 @@ jobs:
           echo The last commit sha in the release: ${{ inputs.sha }}
           echo The release version number:         ${{ inputs.version_number }}
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
+          echo Build script path:                  ${{ inputs.build_script_path }}
+          echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
+          echo Package test command:               ${{ inputs.package_test_command }}
+          echo Check version changelog:            ${{ inputs.audit_version_changelog }} 
+          echo Check build exists:                 ${{ inputs.check_build_exists }}
+          echo Upload build to AWS:                ${{ inputs.upload_artifacts_aws  }}
           echo Test run:                           ${{ inputs.test_run }}
-          echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
-          echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  unit:
-    name: Unit Test
+  build-test-package:
+    name: Build, Test, Package
 
-    runs-on: ubuntu-latest
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/update-build-workflow
 
-    env:
-      TOXENV: "unit"
-
-    steps:
-      - name: "Checkout Commit - ${{ inputs.sha }}"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.inputs.sha }}
-
-      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_TARGET_VERSION }}
-
-      - name: "Install Python Dependencies"
-        run: |
-          python -m pip install --user --upgrade pip
-          python -m pip install tox
-          python -m pip --version
-          python -m tox --version
-
-      - name: "Run Tox"
-        run: tox
-
-  build:
-    name: Build Packages
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout Commit - ${{ inputs.sha }}"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.sha }}
-
-      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_TARGET_VERSION }}
-
-      - name: "Install Python Dependencies"
-        run: |
-          python -m pip install --user --upgrade pip
-          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
-          python -m pip --version
-
-      - name: "Build Distributions"
-        run: ./scripts/build-dist.sh
-
-      - name: "[DEBUG] Show Distributions"
-        run: ls -lh dist/
-
-      - name: "Check Distribution Descriptions"
-        run: |
-          twine check dist/*
-
-      - name: "[DEBUG] Check Wheel Contents"
-        run: |
-          check-wheel-contents dist/*.whl --ignore W007,W008
-
-      - name: "Upload Build Artifact - ${{ inputs.version_number }}"
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ inputs.version_number }}
-          path: |
-            dist/
-            !dist/dbt-${{ inputs.version_number }}.tar.gz
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-
-  test-build:
-    name: Verify Packages
-
-    needs: [unit, build]
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_TARGET_VERSION }}
-
-      - name: "Install Python Dependencies"
-        run: |
-          python -m pip install --user --upgrade pip
-          python -m pip install --upgrade wheel
-          python -m pip --version
-
-      - name: "Download Build Artifact - ${{ inputs.version_number }}"
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.version_number }}
-          path: dist/
-
-      - name: "[DEBUG] Show Distributions"
-        run: ls -lh dist/
-
-      - name: "Install Wheel Distributions"
-        run: |
-          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: "[DEBUG] Check Wheel Distributions"
-        run: |
-          dbt --version
-
-      - name: "Install Source Distributions"
-        run: |
-          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: "[DEBUG] Check Source Distributions"
-        run: |
-          dbt --version
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      build_script_path: ${{ inputs.build_script_path }}
+      s3_bucket_name: ${{ inputs.s3_bucket_name }}
+      package_test_command: ${{ inputs.package_test_command }}
+      audit_version_changelog: ${{ inputs.audit_version_changelog }}
+      check_build_exists: ${{ inputs.check_build_exists }}
+      upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
 
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
       check_build_exists: ${{ inputs.check_build_exists }}
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
 
+    secrets: inherit
+
   github-release:
     name: GitHub Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,14 @@ on:
         type: string
         default: "core-team-artifacts"
         required: true
+      s3_artifact_folder:
+        description: "Folder for arifact"
+        type: choice
+        required: true
+        options:
+          - "artifacts"
+          - "artifacts_testing"
+        default: "artifacts"
       package_test_command:
         description: "Package test command"
         type: string
@@ -79,6 +87,7 @@ jobs:
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Build script path:                  ${{ inputs.build_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
+          echo Folder for arifact:                 ${{ inputs.s3_artifact_folder }}
           echo Package test command:               ${{ inputs.package_test_command }}
           echo Check version changelog:            ${{ inputs.audit_version_changelog }}
           echo Check build exists:                 ${{ inputs.check_build_exists }}
@@ -96,6 +105,7 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       build_script_path: ${{ inputs.build_script_path }}
       s3_bucket_name: ${{ inputs.s3_bucket_name }}
+      s3_artifact_folder: ${{ inputs.s3_artifact_folder }}
       package_test_command: ${{ inputs.package_test_command }}
       audit_version_changelog: ${{ inputs.audit_version_changelog }}
       check_build_exists: ${{ inputs.check_build_exists }}


### PR DESCRIPTION
**Description**:
We need to update the current release workflow to test the Build reusable workflow.

_Changelog_:
- Replace unit, build, and test-build stages with Build workflows;
- Add inputs required for Build workflows;

**Note**:
Merge only after:
- dbt-labs/dbt-release/pull/37
