### PR TITLE
[CI/CD] Update release workflow to reflect new changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,13 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/release-workflow-improve-compatibility
 
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
+      build_script_path: ${{ inputs.build_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,5 @@ jobs:
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      build_script_path: ${{ inputs.build_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
 
     uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/test-token
 
+    secrets: inherit
+
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${{ inputs.env_setup_script_path }}
+      env_setup_script_path: ""
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,5 @@ jobs:
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: "pypi-${{ secrets.TEST_PYPI_API_TOKEN }}"
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ""
+      env_setup_script_path: ${{ inputs.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.version_number }}
-          path: "dist"
+          path: .
 
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/test-token
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${{ input.env_setup_script_path }}
+      env_setup_script_path: ${{ inputs.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,5 @@ jobs:
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
-          password: "pypi-${{ secrets.PYPI_API_TOKEN }}"
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${input.env_setup_script_path }}
+      env_setup_script_path: ${{ input.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     needs: [bump-version-generate-changelog]
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/release-workflow-improve-compatibility
 
     with:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
@@ -153,6 +153,7 @@ jobs:
           path: .
 
       - name: "Publish Distribution To Pypi"
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,5 @@ jobs:
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
-          password: "pypi-${{ secrets.TEST_PYPI_API_TOKEN }}"
+          password: "pypi-${{ secrets.PYPI_API_TOKEN }}"
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,4 +155,4 @@ jobs:
       - name: "Publish Distribution To Pypi"
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/release-workflow-improve-compatibility
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
     with:
       sha: ${{ inputs.sha }}
@@ -105,7 +105,7 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     needs: [bump-version-generate-changelog]
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/release-workflow-improve-compatibility
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
 
     with:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ on:
         type: string
         default: "scripts/build-dist.sh"
         required: true
+      env_setup_script_path:
+        description: "Enviroment setup script path"
+        type: string
+        default: "scripts/env-setup.sh"
+        required: true
       s3_bucket_name:
         description: "AWS S3 bucket name"
         type: string
@@ -64,6 +69,7 @@ jobs:
           echo The branch to release from:         ${{ inputs.target_branch }}
           echo The release version number:         ${{ inputs.version_number }}
           echo Build script path:                  ${{ inputs.build_script_path }}
+          echo Enviroment setup script path:       ${{ inputs.env_setup_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
           echo Package test command:               ${{ inputs.package_test_command }}
           echo Test run:                           ${{ inputs.test_run }}
@@ -77,6 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
+      env_setup_script_path: ${input.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
 
   log-outputs-bump-version-generate-changelog:

--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export DBT_INVOCATION_ENV="github-actions"
-export DBT_TEST_USER_1="dbt_test_user_1"
-export DBT_TEST_USER_2="dbt_test_user_2"
-export DBT_TEST_USER_3="dbt_test_user_3"
+echo "DBT_INVOCATION_ENV=github-actions" >> $GITHUB_ENV
+echo "DBT_TEST_USER_1=dbt_test_user_1" >> $GITHUB_ENV
+echo "DBT_TEST_USER_2=dbt_test_user_2" >> $GITHUB_ENV
+echo "DBT_TEST_USER_3=dbt_test_user_3" >> $GITHUB_ENV

--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export DBT_INVOCATION_ENV= "github-actions"
+export DBT_TEST_USER_1= "dbt_test_user_1"
+export DBT_TEST_USER_2= "dbt_test_user_2"
+export DBT_TEST_USER_3= "dbt_test_user_3"

--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-export DBT_INVOCATION_ENV= "github-actions"
-export DBT_TEST_USER_1= "dbt_test_user_1"
-export DBT_TEST_USER_2= "dbt_test_user_2"
-export DBT_TEST_USER_3= "dbt_test_user_3"
+export DBT_INVOCATION_ENV="github-actions"
+export DBT_TEST_USER_1="dbt_test_user_1"
+export DBT_TEST_USER_2="dbt_test_user_2"
+export DBT_TEST_USER_3="dbt_test_user_3"


### PR DESCRIPTION
**Description**:
We need to update the release workflow to provide the ability to run integration tests during the release preparation stage.

_Changelog_:
- Add `env_setup_script_path` input to point out the file that needs to be executed to set up the environment for integration tests;
- Add `scripts/env-setup.sh` script that contains environment variables declaration;