### PR TITLE
[CI/CD] Switch workflows refs to `dev` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
     needs: [github-release]
 
-    uses: dbt-labs/dbt-release/.github/workflows/pypi-release.yml@users/alexander-smolyakov/pipy-release-improve-workflow
+    uses: dbt-labs/dbt-release/.github/workflows/pypi-release.yml@dev
 
     with:
       version_number: ${{ inputs.version_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@dev
 
     with:
       sha: ${{ inputs.sha }}
@@ -105,7 +105,7 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     needs: [bump-version-generate-changelog]
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@dev
 
     with:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
@@ -126,7 +126,7 @@ jobs:
 
     needs: [bump-version-generate-changelog, build-test-package]
 
-    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@dev
 
     with:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
@@ -139,7 +139,7 @@ jobs:
 
     needs: [github-release]
 
-    uses: dbt-labs/dbt-release/.github/workflows/pypi-release.yml@users/alexander-smolyakov/update-pypi-release-workflow
+    uses: dbt-labs/dbt-release/.github/workflows/pypi-release.yml@users/alexander-smolyakov/pipy-release-improve-workflow
 
     with:
       version_number: ${{ inputs.version_number }}


### PR DESCRIPTION
**Description**:
To test actual changes for the release workflow we need to update tags to use `dev` branch instead of `main`.

_Changelog_:
- Switch refs from `main` to `dev` branch.